### PR TITLE
Support 9.6 still

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MODULE_big	= pgnodemx
 OBJS		= pgnodemx.o cgroup.o envutils.o fileutils.o genutils.o kdapi.o parseutils.o
 PG_CPPFLAGS	= -I$(libpq_srcdir)
 EXTENSION	= pgnodemx
-DATA		= pgnodemx--1.0--1.1.sql pgnodemx--1.1.sql pgnodemx--1.1--1.2.sql
+DATA		= pgnodemx--1.0--1.1.sql pgnodemx--1.1--1.2.sql pgnodemx--1.2.sql
 
 GHASH := $(shell git rev-parse --short HEAD)
 

--- a/pgnodemx--1.2.sql
+++ b/pgnodemx--1.2.sql
@@ -1,4 +1,4 @@
-/* contrib/pgnodemx/pgnodemx--1.1.sql */
+/* contrib/pgnodemx/pgnodemx--1.2.sql */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pgnodemx" to load this file. \quit
@@ -173,18 +173,18 @@ LANGUAGE C STABLE STRICT;
 CREATE FUNCTION fsinfo
 (
   IN pathname TEXT,
-  OUT major_number BIGINT,
-  OUT minor_number BIGINT,
+  OUT major_number NUMERIC,
+  OUT minor_number NUMERIC,
   OUT type TEXT,
-  OUT block_size BIGINT,
-  OUT blocks BIGINT,
-  OUT total_bytes BIGINT,
-  OUT free_blocks BIGINT,
-  OUT free_bytes BIGINT,
-  OUT available_blocks BIGINT,
-  OUT available_bytes BIGINT,
-  OUT total_file_nodes BIGINT,
-  OUT free_file_nodes BIGINT,
+  OUT block_size NUMERIC,
+  OUT blocks NUMERIC,
+  OUT total_bytes NUMERIC,
+  OUT free_blocks NUMERIC,
+  OUT free_bytes NUMERIC,
+  OUT available_blocks NUMERIC,
+  OUT available_bytes NUMERIC,
+  OUT total_file_nodes NUMERIC,
+  OUT free_file_nodes NUMERIC,
   OUT mount_flags TEXT
 )
 RETURNS SETOF record


### PR DESCRIPTION
Considering that there is still a final release of 9.6 to be made, we can't quite drop support for this yet; 9.6 still requires the installed version to have a base SQL file to be installed.

Additionally, having the latest base version only is good practice considering that we are not binary compatible with 1.1, but would still allow `ALTER EXTENSION pgnodemx UPDATE TO '1.1'` to succeed.  Removing the intermediate base means this is no longer a potential loophole, and this extension joins the legion of "update only" ones.

While at it, I'd like to propose that we match the tag/packaging version of the module to the underlying extension version; I think this will be quite a bit less confusing in the long run.

