### PR TITLE
OpenSSL 3 removes FIPS_mode

### DIFF
--- a/pgnodemx.c
+++ b/pgnodemx.c
@@ -685,7 +685,11 @@ pgnodemx_fips_mode(PG_FUNCTION_ARGS)
 	pgnodemx_check_role();
 
 #ifdef USE_OPENSSL
+#if OPENSSL_VERSION_MAJOR >= 3
+	if (EVP_default_properties_is_fips_enabled(NULL))
+#else
 	if (FIPS_mode())
+#endif
 		PG_RETURN_BOOL(true);
 	else
 		PG_RETURN_BOOL(false);


### PR DESCRIPTION
In OpenSSL 3, FIPS_mode() is removed. Replace using EVP_default_properties_is_fips_enabled().

Compiling with OpenSSL, FIPS_mode raises errors:
```
pgnodemx.c: In function ‘pgnodemx_fips_mode’:
pgnodemx.c:688:13: warning: implicit declaration of function ‘FIPS_mode’ [-Wimplicit-function-declaration]
  688 |         if (FIPS_mode())
      |             ^~~~~~~~~

postgres=# create extension pgnodemx with schema exporter ;
ERROR:  could not load library "/usr/pgsql-14-tde/lib/pgnodemx.so": /usr/pgsql-14-tde/lib/pgnodemx.so: undefined symbol: FIPS_mode
```

Redhat ships a /usr/include/openssl/fips.h header that restores the definition:
```
# define FIPS_mode() EVP_default_properties_is_fips_enabled(NULL)
```
... but at least on my Debian system, that header isn't present, so properly call `EVP_default_properties_is_fips_enabled()` in pgnodemx.c.