### PR TITLE
Remove Call to tuplestore_donestoring for PG 17

### DIFF
--- a/genutils.c
+++ b/genutils.c
@@ -278,7 +278,6 @@ form_srf(FunctionCallInfo fcinfo, char ***values, int nrow, int ncol, Oid *dtype
 	 */
 	ReleaseTupleDesc(tupdesc);
 
-	tuplestore_donestoring(tupstore);
 	rsinfo->setResult = tupstore;
 
 	/*


### PR DESCRIPTION
When building `pgnodemx` with Postgres 17, the following error is seen:

```bash
genutils.c: In function ‘form_srf’:
genutils.c:281:9: error: implicit declaration of function ‘tuplestore_donestoring’; did you mean ‘tuplestore_rescan’? [-Wimplicit-function-declaration]
  281 |         tuplestore_donestoring(tupstore);
      |         ^~~~~~~~~~~~~~~~~~~~~~
      |         tuplestore_rescan
```

Further analysis shows indicates that `tuplestore_donestoring` was removed in Postgres 17:

- https://github.com/postgres/postgres/blob/REL_17_BETA3/src/include/utils/tuplestore.h
- https://www.postgresql.org/message-id/flat/20231121045840.GD3521465%40nathanxps13#fcc993d664f8b3355f0691751c12e44d

Additionally, looking back at the previous version of Postgres where `tuplestore_donestoring` was still present, we can see that it has been a no-op for some time now (well past all actively supported versions of PG):

- https://github.com/postgres/postgres/blob/320534f8f25bf5aa2de4ad1f561b71219cb4e5ff/src/include/utils/tuplestore.h#L59-L60
- https://github.com/postgres/postgres/blob/ecd19a3cc1879118424ce730369dcfe3d7a41d75/src/include/utils/tuplestore.h#L59-L60
- https://github.com/postgres/postgres/blob/9fe6319dcc1060c9b65d13f61440bfcfc772803a/src/include/utils/tuplestore.h#L59-L60

Therefore, fixing this appears to be as simple as removing the line with the cll to `tuplestore_donestoring`.  This is discussed in the [PG mailing list thread](https://www.postgresql.org/message-id/flat/20231121045840.GD3521465%40nathanxps13#fcc993d664f8b3355f0691751c12e44d) for the removal of `tuplestore_donestoring`:

> …Even if an extension is using them today, you'll get
the same behavior as before if you remove the uses and rebuild against
v12-v16.

This PR therefore removes a call to `tuplestore_donestoring` for proper compatibility with Postgres 17.
